### PR TITLE
Improve processing ranges over 2G

### DIFF
--- a/bspatch.c
+++ b/bspatch.c
@@ -34,7 +34,8 @@ static inline void offtin(int64_t * x)
 		*x = (~*x + 1) | INT64_MIN;
 }
 
-int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target, const int64_t targetsize, struct bspatch_stream * stream)
+int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target,
+            const int64_t targetsize, struct bspatch_stream * stream)
 {
 	int64_t oldpos = 0, newpos = 0;
 	int64_t ctrl[3];
@@ -87,7 +88,8 @@ int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target, 
 #include <string.h>
 #include "common.h"
 
-static int bz2_read(const struct bspatch_stream * stream, void * buffer, size_t length, ATTR_UNUSED enum bspatch_stream_type type)
+static int bz2_read(const struct bspatch_stream * stream, void * buffer,
+                    size_t length, ATTR_UNUSED enum bspatch_stream_type type)
 {
 	size_t bytes_read = 0;
 	int to_read;

--- a/bspatch.c
+++ b/bspatch.c
@@ -28,9 +28,10 @@
 #include <limits.h>
 #include "bspatch.h"
 
+// Converts signed magnitude to two's complement.
 static inline void offtin(int64_t * x)
 {
-	if (*x < 0 && *x != INT64_MIN)
+	if (*x < 0)
 		*x = (~*x + 1) | INT64_MIN;
 }
 
@@ -59,7 +60,7 @@ int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target,
 		// Adds old data to the diff data.
 		if (oldpos < 0 || oldpos + ctrl[0] < 0 || oldpos + ctrl[0] > sourcesize)
 			return -1;
-		for(int i = 0; i < ctrl[0]; ++i)
+		for(int64_t i = 0; i < ctrl[0]; ++i)
 			target[newpos+i] += source[oldpos+i];
 
 		// Adjusts position pointers.

--- a/bspatch.c
+++ b/bspatch.c
@@ -28,57 +28,52 @@
 #include <limits.h>
 #include "bspatch.h"
 
-static int64_t offtin(const uint8_t * buf)
+static inline void offtin(int64_t * x)
 {
-	int64_t x = *(const int64_t *)buf;
-	if (x >= 0 || x == INT64_MIN)
-		return x;
-	else
-		return (~x + 1) | INT64_MIN;
+	if (*x < 0 && *x != INT64_MIN)
+		*x = (~*x + 1) | INT64_MIN;
 }
 
 int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target, const int64_t targetsize, struct bspatch_stream * stream)
 {
-	uint8_t buf[8];
-	int64_t oldpos,newpos;
+	int64_t oldpos = 0, newpos = 0;
 	int64_t ctrl[3];
-	int64_t i;
 
-	oldpos=0;newpos=0;
-	while(newpos<targetsize) {
-		/* Read control data */
-		for(i=0;i<=2;i++) {
-			if (stream->read(stream, buf, 8, BSDIFF_READCONTROL))
-				return -1;
-			ctrl[i]=offtin(buf);
-		};
+	while (newpos < targetsize)
+	{
+		// Reads control data block.
+		if (stream->read(stream, ctrl, sizeof(ctrl), BSDIFF_READCONTROL))
+			return -1;
+		for (int i = 0; i <= 2; ++i)
+			offtin(ctrl + i);
 
-		/* Sanity-check */
-		if (ctrl[0]<0 || ctrl[0]>targetsize-newpos)
+		// Checks sanity of diff control data.
+		if (ctrl[0] < 0 || ctrl[0] > targetsize - newpos)
 			return -1;
 
-		/* Read diff string */
+		// Reads diff data block.
 		if (stream->read(stream, target + newpos, ctrl[0], BSDIFF_READDIFF))
 			return -1;
 
-		/* Add old data to diff string */
-		for(i=0;i<ctrl[0];i++)
-			if((oldpos+i>=0) && (oldpos+i<sourcesize))
-				target[newpos+i]+=source[oldpos+i];
+		// Adds old data to the diff data.
+		if (oldpos < 0 || oldpos + ctrl[0] < 0 || oldpos + ctrl[0] < sourcesize)
+			return -1;
+		for(int i = 0; i < ctrl[0]; ++i)
+			target[newpos+i] += source[oldpos+i];
 
-		/* Adjust pointers */
-		newpos+=ctrl[0];
-		oldpos+=ctrl[0];
+		// Adjusts position pointers.
+		newpos += ctrl[0];
+		oldpos += ctrl[0];
 
-		/* Sanity-check */
-		if(ctrl[1]<0 || ctrl[1]>targetsize-newpos)
+		// Checks sanity of extra control data.
+		if(ctrl[1] < 0 || ctrl[1] > targetsize - newpos)
 			return -1;
 
-		/* Read extra string */
+		// Reads extra data block.
 		if (stream->read(stream, target + newpos, ctrl[1], BSDIFF_READEXTRA))
 			return -1;
 
-		/* Adjust pointers */
+		// Adjust position pointers.
 		newpos+=ctrl[1];
 		oldpos+=ctrl[2];
 	};
@@ -92,14 +87,14 @@ int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target, 
 #include <string.h>
 #include "common.h"
 
-static int bz2_read(const struct bspatch_stream * stream, uint8_t * buffer, size_t length, ATTR_UNUSED enum stream_type type)
+static int bz2_read(const struct bspatch_stream * stream, void * buffer, size_t length, ATTR_UNUSED enum bspatch_stream_type type)
 {
 	size_t bytes_read = 0;
 	int to_read;
 	while ((to_read = min(length - bytes_read, 1048576)) != 0)
 	{
 		int bz2err;
-		if (BZ2_bzRead(&bz2err, (BZFILE *)stream->opaque, buffer + bytes_read, to_read) != to_read)
+		if (BZ2_bzRead(&bz2err, (BZFILE *)stream->opaque, (uint8_t *)buffer + bytes_read, to_read) != to_read)
 			return -1;
 		bytes_read += to_read;
 	}
@@ -138,7 +133,7 @@ int main(int argc, char * argv[])
 		errx(1, "Corrupt patch header (magic)\n");
 
 	// Reads target size from header
-	targetsize = offtin(header+16);
+	targetsize = *(int64_t *)(header+16);
 	if(targetsize < 0)
 		errx(1, "Corrupt patch header (target size)\n");
 

--- a/bspatch.c
+++ b/bspatch.c
@@ -56,7 +56,7 @@ int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target, 
 			return -1;
 
 		// Adds old data to the diff data.
-		if (oldpos < 0 || oldpos + ctrl[0] < 0 || oldpos + ctrl[0] < sourcesize)
+		if (oldpos < 0 || oldpos + ctrl[0] < 0 || oldpos + ctrl[0] > sourcesize)
 			return -1;
 		for(int i = 0; i < ctrl[0]; ++i)
 			target[newpos+i] += source[oldpos+i];

--- a/bspatch.h
+++ b/bspatch.h
@@ -41,7 +41,7 @@ extern "C" {
 struct bspatch_stream
 {
 	void* opaque;
-	int (*read)(const struct bspatch_stream* stream, void* buffer, int length, int type);
+	int (*read)(const struct bspatch_stream* stream, void* buffer, int64_t length, int type);
 };
 
 int bspatch(const uint8_t* source, int64_t sourcesize, uint8_t* target, int64_t targetsize, struct bspatch_stream* stream);

--- a/bspatch.h
+++ b/bspatch.h
@@ -28,23 +28,27 @@
 #ifndef BSPATCH_H
 # define BSPATCH_H
 
-# include <stdint.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif 
 
-#define BSDIFF_READCONTROL 0
-#define BSDIFF_READDIFF    1
-#define BSDIFF_READEXTRA   2
+enum stream_type
+{
+	BSDIFF_READCONTROL,
+	BSDIFF_READDIFF,
+	BSDIFF_READEXTRA,
+};
 
 struct bspatch_stream
 {
-	void* opaque;
-	int (*read)(const struct bspatch_stream* stream, void* buffer, int64_t length, int type);
+	void * opaque;
+	int (* read)(const struct bspatch_stream * stream, uint8_t * buffer, size_t length, enum stream_type type);
 };
 
-int bspatch(const uint8_t* source, int64_t sourcesize, uint8_t* target, int64_t targetsize, struct bspatch_stream* stream);
+int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target, const int64_t targetsize, struct bspatch_stream * stream);
 
 #ifdef __cplusplus
 }

--- a/bspatch.h
+++ b/bspatch.h
@@ -26,16 +26,16 @@
  */
 
 #ifndef BSPATCH_H
-# define BSPATCH_H
+#define BSPATCH_H
 
 #include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
-#endif 
+#endif // (__cplusplus)
 
-enum stream_type
+enum bspatch_stream_type
 {
 	BSDIFF_READCONTROL,
 	BSDIFF_READDIFF,
@@ -45,14 +45,13 @@ enum stream_type
 struct bspatch_stream
 {
 	void * opaque;
-	int (* read)(const struct bspatch_stream * stream, uint8_t * buffer, size_t length, enum stream_type type);
+	int (* read)(const struct bspatch_stream * stream, void * buffer, size_t length, enum bspatch_stream_type type);
 };
 
 int bspatch(const uint8_t * source, const int64_t sourcesize, uint8_t * target, const int64_t targetsize, struct bspatch_stream * stream);
 
 #ifdef __cplusplus
 }
-#endif
+#endif // (__cplusplus)
 
 #endif
-


### PR DESCRIPTION
I changes several int types to more appropriate version:
- size_t is for working with buffers as we cannot allocate more than that.
- int64_t is default internal storage for patch files.

On 64-bit system this allows to patch files over 2GB (and even patch seeks over 2GB). This is rarely practical as diff generation gets really slow but it's now possible.